### PR TITLE
ProductStock: Provide getter for EshopProduct so extending types can use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Default sorting for Products and Categories
+- Language relation for product reviews.
 
 ### Changed
 

--- a/src/Product/DataType/ProductStock.php
+++ b/src/Product/DataType/ProductStock.php
@@ -12,13 +12,14 @@ namespace OxidEsales\GraphQL\Catalogue\Product\DataType;
 use DateTimeInterface;
 use OxidEsales\Eshop\Application\Model\Article as EshopProductModel;
 use OxidEsales\GraphQL\Base\DataType\DateTimeImmutableFactory;
+use OxidEsales\GraphQL\Catalogue\Shared\DataType\DataType;
 use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 
 /**
  * @Type()
  */
-final class ProductStock
+final class ProductStock implements DataType
 {
     /** @var EshopProductModel */
     private $product;
@@ -27,6 +28,11 @@ final class ProductStock
         EshopProductModel $product
     ) {
         $this->product = $product;
+    }
+
+    public function getEshopModel(): EshopProductModel
+    {
+        return $this->product;
     }
 
     /**
@@ -66,5 +72,13 @@ final class ProductStock
         return DateTimeImmutableFactory::fromString(
             $restockDate
         );
+    }
+
+    /**
+     * @return string class-string
+     */
+    public static function getModelClass(): string
+    {
+        return EshopProductModel::class;
     }
 }

--- a/src/Review/Infrastructure/Review.php
+++ b/src/Review/Infrastructure/Review.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\GraphQL\Catalogue\Review\Infrastructure;
+
+use OxidEsales\GraphQL\Catalogue\Review\DataType\Review as ReviewDataType;
+use OxidEsales\GraphQL\Catalogue\Shared\DataType\Language;
+
+final class Review
+{
+    public function getLanguage(ReviewDataType $review): Language
+    {
+        $languageId = $review->getEshopModel()->getFieldData('oxlang');
+
+        return new Language((int) $languageId);
+    }
+}

--- a/src/Review/Service/RelationService.php
+++ b/src/Review/Service/RelationService.php
@@ -15,7 +15,9 @@ use OxidEsales\GraphQL\Catalogue\Product\Exception\ProductNotFound;
 use OxidEsales\GraphQL\Catalogue\Product\Service\Product as ProductService;
 use OxidEsales\GraphQL\Catalogue\Review\DataType\Review;
 use OxidEsales\GraphQL\Catalogue\Review\DataType\Reviewer;
+use OxidEsales\GraphQL\Catalogue\Review\Infrastructure\Review as ReviewInfrastructure;
 use OxidEsales\GraphQL\Catalogue\Review\Service\Reviewer as ReviewerService;
+use OxidEsales\GraphQL\Catalogue\Shared\DataType\Language;
 use TheCodingMachine\GraphQLite\Annotations\ExtendType;
 use TheCodingMachine\GraphQLite\Annotations\Field;
 
@@ -30,12 +32,17 @@ final class RelationService
     /** @var ReviewerService */
     private $reviewerService;
 
+    /** @var ReviewInfrastructure */
+    private $reviewInfrastructure;
+
     public function __construct(
         ProductService $productService,
-        ReviewerService $reviewerService
+        ReviewerService $reviewerService,
+        ReviewInfrastructure $reviewInfrastructure
     ) {
-        $this->productService     = $productService;
-        $this->reviewerService    = $reviewerService;
+        $this->productService          = $productService;
+        $this->reviewerService         = $reviewerService;
+        $this->reviewInfrastructure    = $reviewInfrastructure;
     }
 
     /**
@@ -63,5 +70,13 @@ final class RelationService
         } catch (ProductNotFound | InvalidLogin $e) {
             return null;
         }
+    }
+
+    /**
+     * @Field()
+     */
+    public function getLanguage(Review $review): Language
+    {
+        return $this->reviewInfrastructure->getLanguage($review);
     }
 }

--- a/src/Shared/DataType/Language.php
+++ b/src/Shared/DataType/Language.php
@@ -34,7 +34,7 @@ final class Language
         return new ID($this->getLanguageId());
     }
 
-    public function getLanguageId()
+    public function getLanguageId(): int
     {
         return $this->languageId;
     }

--- a/src/Shared/DataType/Language.php
+++ b/src/Shared/DataType/Language.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\GraphQL\Catalogue\Shared\DataType;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Types\ID;
+
+/**
+ * @Type()
+ */
+final class Language
+{
+    /** @var int */
+    private $languageId;
+
+    public function __construct(int $languageId)
+    {
+        $this->languageId = $languageId;
+    }
+
+    /**
+     * @Field()
+     */
+    public function getId(): ID
+    {
+        return new ID($this->getLanguageId());
+    }
+
+    public function getLanguageId()
+    {
+        return $this->languageId;
+    }
+}

--- a/src/Shared/Infrastructure/LanguageInfrastructure.php
+++ b/src/Shared/Infrastructure/LanguageInfrastructure.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\GraphQL\Catalogue\Shared\Infrastructure;
+
+use OxidEsales\Eshop\Core\Language as LanguageService;
+
+final class LanguageInfrastructure
+{
+    /** @var LanguageService */
+    private $languageService;
+
+    public function __construct(
+        LanguageService $languageService
+    ) {
+        $this->languageService = $languageService;
+    }
+
+    public function getLanguageCode(int $languageId): string
+    {
+        return $this->languageService->getLanguageAbbr($languageId);
+    }
+
+    public function getLanguageName(int $languageId): string
+    {
+        $languageNames = $this->languageService->getLanguageNames();
+
+        return $languageNames[$languageId];
+    }
+}

--- a/src/Shared/Service/LanguageRelationService.php
+++ b/src/Shared/Service/LanguageRelationService.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace OxidEsales\GraphQL\Catalogue\Shared\Service;
 
-use OxidEsales\Eshop\Core\Language as LanguageService;
 use OxidEsales\GraphQL\Catalogue\Shared\DataType\Language;
+use OxidEsales\GraphQL\Catalogue\Shared\Infrastructure\LanguageInfrastructure;
 use TheCodingMachine\GraphQLite\Annotations\ExtendType;
 use TheCodingMachine\GraphQLite\Annotations\Field;
 
@@ -19,13 +19,13 @@ use TheCodingMachine\GraphQLite\Annotations\Field;
  */
 final class LanguageRelationService
 {
-    /** @var LanguageService */
-    private $languageService;
+    /** @var LanguageInfrastructure */
+    private $languageInfrastructure;
 
     public function __construct(
-        LanguageService $languageService
+        LanguageInfrastructure $languageInfrastructure
     ) {
-        $this->languageService = $languageService;
+        $this->languageInfrastructure = $languageInfrastructure;
     }
 
     /**
@@ -33,9 +33,7 @@ final class LanguageRelationService
      */
     public function getCode(Language $language): string
     {
-        $languageId = $language->getLanguageId();
-
-        return $this->languageService->getLanguageAbbr($languageId);
+        return $this->languageInfrastructure->getLanguageCode($language->getLanguageId());
     }
 
     /**
@@ -43,9 +41,6 @@ final class LanguageRelationService
      */
     public function getLanguage(Language $language): string
     {
-        $languageId = $language->getLanguageId();
-        $languageNames = $this->languageService->getLanguageNames();
-
-        return $languageNames[$languageId];
+        return $this->languageInfrastructure->getLanguageName($language->getLanguageId());
     }
 }

--- a/src/Shared/Service/LanguageRelationService.php
+++ b/src/Shared/Service/LanguageRelationService.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\GraphQL\Catalogue\Shared\Service;
+
+use OxidEsales\Eshop\Core\Language as LanguageService;
+use OxidEsales\GraphQL\Catalogue\Shared\DataType\Language;
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+
+/**
+ * @ExtendType(class=Language::class)
+ */
+final class LanguageRelationService
+{
+    /** @var LanguageService */
+    private $languageService;
+
+    public function __construct(
+        LanguageService $languageService
+    ) {
+        $this->languageService = $languageService;
+    }
+
+    /**
+     * @Field()
+     */
+    public function getCode(Language $language): string
+    {
+        $languageId = $language->getLanguageId();
+
+        return $this->languageService->getLanguageAbbr($languageId);
+    }
+
+    /**
+     * @Field()
+     */
+    public function getLanguage(Language $language): string
+    {
+        $languageId = $language->getLanguageId();
+        $languageNames = $this->languageService->getLanguageNames();
+
+        return $languageNames[$languageId];
+    }
+}

--- a/tests/Fixtures/testdemodata.sql
+++ b/tests/Fixtures/testdemodata.sql
@@ -60,13 +60,15 @@ INSERT INTO `oxratings` (`OXID`, `OXUSERID`, `OXTYPE`, `OXOBJECTID`, `OXRATING`)
 ('_test_more_ratings_3', 'e7af1c3b786fd02906ccd75698f4e6b9', 'oxarticle', '058e613db53d782adfc9f2ccb43c45fe', 4);
 
 UPDATE `oxreviews` SET `OXACTIVE` = 1 WHERE `OXID` = '94415306f824dc1aa2fce0dc4f12783d';
-INSERT INTO `oxreviews` (`OXID`, `OXACTIVE`, `OXOBJECTID`, `OXTYPE`, `OXTEXT`, `OXUSERID`, `OXRATING`) VALUES
-('_test_wrong_user', 1, 'b56597806428de2f58b1c6c7d3e0e093', 'oxarticle', 'example wrong userid text', 'wronguserid', 4),
-('_test_wrong_product', 1, 'wrongobjectid', 'oxarticle', 'example wrong userid text', 'e7af1c3b786fd02906ccd75698f4e6b9', 4),
-('_test_wrong_object_type', 1, 'wrongobjectid', 'oxrecommlist', 'example wrong userid text', 'e7af1c3b786fd02906ccd75698f4e6b9', 4),
-('_test_real_product_1', 1, '058e613db53d782adfc9f2ccb43c45fe', 'oxarticle', 'example review for product 1', 'e7af1c3b786fd02906ccd75698f4e6b9', 3),
-('_test_real_product_2', 1, '058e613db53d782adfc9f2ccb43c45fe', 'oxarticle', 'example review for product 2', 'e7af1c3b786fd02906ccd75698f4e6b9', 4),
-('_test_real_product_inactive', 0, '058e613db53d782adfc9f2ccb43c45fe', 'oxarticle', 'example review for product inactive', 'e7af1c3b786fd02906ccd75698f4e6b9', 5);
+INSERT INTO `oxreviews` (`OXID`, `OXACTIVE`, `OXOBJECTID`, `OXTYPE`, `OXTEXT`, `OXUSERID`, `OXRATING`, `OXLANG`) VALUES
+('_test_wrong_user', 1, 'b56597806428de2f58b1c6c7d3e0e093', 'oxarticle', 'example wrong userid text', 'wronguserid', 4, 0),
+('_test_wrong_product', 1, 'wrongobjectid', 'oxarticle', 'example wrong userid text', 'e7af1c3b786fd02906ccd75698f4e6b9', 4, 0),
+('_test_wrong_object_type', 1, 'wrongobjectid', 'oxrecommlist', 'example wrong userid text', 'e7af1c3b786fd02906ccd75698f4e6b9', 4, 0),
+('_test_real_product_1', 1, '058e613db53d782adfc9f2ccb43c45fe', 'oxarticle', 'example review for product 1', 'e7af1c3b786fd02906ccd75698f4e6b9', 3, 0),
+('_test_real_product_2', 1, '058e613db53d782adfc9f2ccb43c45fe', 'oxarticle', 'example review for product 2', 'e7af1c3b786fd02906ccd75698f4e6b9', 4, 0),
+('_test_real_product_inactive', 0, '058e613db53d782adfc9f2ccb43c45fe', 'oxarticle', 'example review for product inactive', 'e7af1c3b786fd02906ccd75698f4e6b9', 5, 0),
+('_test_lang_0_review', 1, 'notreal', 'oxarticle', 'example lang 0 review', 'e7af1c3b786fd02906ccd75698f4e6b9', 5, 0),
+('_test_lang_1_review', 1, 'notreal', 'oxarticle', 'example lang 1 review', 'e7af1c3b786fd02906ccd75698f4e6b9', 5, 1);
 
 UPDATE `oxlinks` SET `OXACTIVE` = 0 WHERE `OXID` = 'ce342e8acb69f1748.25672556';
 INSERT INTO `oxlinks` (`OXID`, `OXSHOPID`, `OXACTIVE`, `OXURL`, `OXURLDESC`, `OXURLDESC_1`, `OXURLDESC_2`, `OXURLDESC_3`, `OXINSERT`) VALUES

--- a/tests/Integration/Controller/ReviewMultilanguageTest.php
+++ b/tests/Integration/Controller/ReviewMultilanguageTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\GraphQL\Catalogue\Tests\Integration\Controller;
+
+use OxidEsales\GraphQL\Base\Tests\Integration\TestCase;
+
+final class ReviewMultilanguageTest extends TestCase
+{
+    /**
+     * @param $languageId
+     * @param $expectedLanguage
+     *
+     * @dataProvider multipleLanguageReviewsDataProvider
+     */
+    public function testMultipleLanguageReviews($languageId, $expectedLanguage): void
+    {
+        // Ensure we dont have shop and lang params affecting our review data
+        $this->setGETRequestParameter('shp', '2');
+        $this->setGETRequestParameter('lang', '1');
+
+        $result = $this->query('query {
+            review(id: "_test_lang_' . $languageId . '_review") {
+                id
+                language {
+                    id
+                    code
+                    language
+                }
+            }
+        }');
+
+        $this->assertResponseStatus(
+            200,
+            $result
+        );
+
+        $review = $result['body']['data']['review'];
+
+        $this->assertSame($expectedLanguage, $review['language']);
+    }
+
+    public function multipleLanguageReviewsDataProvider()
+    {
+        return [
+            [
+                'languageId'       => 0,
+                'expectedLanguage' => [
+                    'id'       => '0',
+                    'code'     => 'de',
+                    'language' => 'Deutsch',
+                ],
+            ],
+            [
+                'languageId'       => 1,
+                'expectedLanguage' => [
+                    'id'       => '1',
+                    'code'     => 'en',
+                    'language' => 'English',
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
If you want to extend the `ProductStock` data type e.g. by adding a stock flag you have no access to the `EshopProductModel`.  
To allow this we have added `getEshopModel` and the `DataType` interface to `ProductStock`.